### PR TITLE
Updated config parsing to use host attribute in line with README.md

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -11,7 +11,7 @@
     {
       "accessory": "sony-sdcp-projector",
       "name": "Projector",
-      "ip": "Sony.Projector.IP.Address"
+      "host": "xxx.xxx.xxx.xxx or hostname"
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function ProjectorAccessory(log, config) {
     this.config = config;
     this.name = config["name"];
     this.lastState = 0;
-    this.myClient = SdcpClient.SdcpClient({address: this.config["ip"], port: PORT});
+    this.myClient = SdcpClient.SdcpClient({address: this.config["host"], port: PORT});
 
     this.service = new Service.Switch(this.name);
     this.service


### PR DESCRIPTION
The example config in README.md refers to the host attribute for the projector, but index.js was looking for an ip attribute instead. Pull request includes a simple update to index.js to use host. The underlying connect call to Net.Socket will resolve both a hostname and an ip address so "host" seemed more appropriate than ip.